### PR TITLE
make Julia 0.5 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ and returns immediately.
 #### Actions
 
 * `ActPromise(stream_identifier, promised_stream_identifier, headers)`: This is
-  usually sends from a server, which sends a push promise. `stream_identifier`
+  usually sent from a server which sends a push promise. `stream_identifier`
   is the main stream identifier, `promised_stream_identifier` is the promised
   stream identifier that is going to be pushed, and `headers` are a `Headers`
   struct that sends the requests.
@@ -140,7 +140,7 @@ and returns immediately.
   HTTP specification. If there's no more headers or data to be sent in the
   stream, `is_end_stream` should set to true.
 * `ActSendData(stream_identifier, data, is_end_stream)`: This can be used to
-  send request body, response body, or if a protocol switch is initialize, other
+  send request body, response body, or if a protocol switch is initialized, other
   specified protocol data. If there's no more headers or data to be sent in the
   stream, `is_end_stream` should set to true.
 

--- a/src/Frame.jl
+++ b/src/Frame.jl
@@ -11,12 +11,12 @@ immutable FrameHeader
 end
 
 function decode_header(buf)
-    length_arr = readbytes(buf, 3)
+    length_arr = read(buf, 3)
     length = UInt32(length_arr[1]) << 16 + UInt32(length_arr[2]) << 8 + UInt32(length_arr[3])
 
-    typ = FRAME_TYPES(readbytes(buf, 1)[1])
-    flags = readbytes(buf, 1)[1]
-    stream_identifier_arr = readbytes(buf, 4)
+    typ = FRAME_TYPES(read(buf, 1)[1])
+    flags = read(buf, 1)[1]
+    stream_identifier_arr = read(buf, 4)
     stream_identifier = UInt32(stream_identifier_arr[1]) << 24 + UInt32(stream_identifier_arr[2]) << 16 +
         UInt32(stream_identifier_arr[3]) << 8 + UInt32(stream_identifier_arr[4])
 
@@ -57,7 +57,7 @@ include("Frame/continuation.jl")
 
 function decode(buf)
     header = decode_header(buf)
-    payload = readbytes(buf, header.length)
+    payload = read(buf, header.length)
     @assert length(payload) == header.length
 
     if header.typ == DATA

--- a/src/Session/channels.jl
+++ b/src/Session/channels.jl
@@ -10,7 +10,7 @@ function initialize_raw_loop_async(connection::HTTPConnection, buffer; skip_pref
         if connection.isclient
             write(buffer, CLIENT_PREFACE)
         else
-            @assert readbytes(buffer, length(CLIENT_PREFACE)) == CLIENT_PREFACE
+            @assert read(buffer, length(CLIENT_PREFACE)) == CLIENT_PREFACE
         end
     end
 


### PR DESCRIPTION
- uses Compat.jl to make this Julia 0.5 compatible
- minor typo fixes on README.md
- add Julia 0.4 to travis test matrix