### PR TITLE
Ignore unknown setting identifiers

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-HPack 0.2.0
+HPack 0.1.0
 HttpCommon 0.2.4

--- a/src/Frame.jl
+++ b/src/Frame.jl
@@ -37,7 +37,7 @@ function encode_header(header::FrameHeader)
     write(buf, UInt8(header.stream_identifier >> 24), UInt8((header.stream_identifier >> 16) & 0x000000ff),
           UInt8((header.stream_identifier >> 8) & 0x000000ff), UInt8(header.stream_identifier & 0x000000ff))
 
-    return takebuf_array(buf)
+    return take!(buf)
 end
 
 

--- a/src/Frame/settings.jl
+++ b/src/Frame/settings.jl
@@ -27,7 +27,9 @@ function decode_settings(header, payload)
             identifier = UInt16(payload[(i-1)*6+1]) << 8 + UInt16(payload[(i-1)*6+2])
             value = UInt32(payload[(i-1)*6+3]) << 24 + UInt32(payload[(i-1)*6+4]) << 16 +
                 UInt32(payload[(i-1)*6+5]) << 8 + UInt32(payload[(i-1)*6+6])
-            push!(parameters, (SETTING_IDENTIFIER(identifier), value))
+            if identifier <= 0x6
+                push!(parameters, (SETTING_IDENTIFIER(identifier), value))
+            end
         end
         return SettingsFrame(is_ack, Nullable(parameters))
     end

--- a/src/Session.jl
+++ b/src/Session.jl
@@ -98,10 +98,10 @@ HTTPConnection(isclient) = HTTPConnection(HPack.new_dynamic_table(),
                                           HTTPSettings(),
                                           false,
 
-                                          Channel(),
-                                          Channel(),
-                                          Channel(),
-                                          Channel())
+                                          Channel(32),
+                                          Channel(32),
+                                          Channel(32),
+                                          Channel(32))
 
 function next_free_stream_identifier(connection::HTTPConnection)
     return connection.last_stream_identifier + 2


### PR DESCRIPTION
This is to handle the case where the server send back a non-standard setting identifier. There's probably a better way to handle this, but in this PR they are merely ignored.

The original cause an error in Julia v0.6 because it is not one of the defined enum value.

One case where this can happen is when using it for GRPC, which has a nonstandard setting field.